### PR TITLE
Add patch for SWEAP support in SWE-ReX

### DIFF
--- a/src/swerex/deployment/config.py
+++ b/src/swerex/deployment/config.py
@@ -93,7 +93,7 @@ class ModalDeploymentConfig(BaseModel):
     """Runtime timeout (default timeout for all runtime requests)
     """
 
-    deployment_timeout: float = 1800.0
+    deployment_timeout: float = 3600.0
     """Kill deployment after this many seconds no matter what.
     This is a useful killing switch to ensure that you don't spend too 
     much money on modal.

--- a/src/swerex/deployment/modal.py
+++ b/src/swerex/deployment/modal.py
@@ -69,6 +69,7 @@ class _ImageBuilder:
         try:
             # Build image for SWEAP instances
             # TODO: Expand for more use cases rather than just SWEAP
+            # TODO: Move AWS Secret from a username specific name to a generic one
             return modal.Image.from_aws_ecr(  # type: ignore
                 image,
                 secret=modal.Secret.from_name("aws-secret-ml-xiang-deng"),

--- a/src/swerex/runtime/remote.py
+++ b/src/swerex/runtime/remote.py
@@ -123,7 +123,10 @@ class RemoteRuntime(AbstractRuntime):
     def _get_retry_decorator(self, safe_to_retry: bool = True) -> Any:
         """Returns a tenacity retry decorator based on the instance's configuration."""
         if not safe_to_retry:
-            return None  # No retry for unsafe operations
+            # Return a no-op decorator if the function is not safe to retry.
+            def no_op_decorator(func):
+                return func
+            return no_op_decorator
 
         return retry(
             stop=stop_after_attempt(self.max_retries + 1),

--- a/src/swerex/runtime/remote.py
+++ b/src/swerex/runtime/remote.py
@@ -2,13 +2,21 @@ import logging
 import shutil
 import sys
 import tempfile
-import time
 import traceback
 from pathlib import Path
 from typing import Any
 
 import requests
 from pydantic import BaseModel
+from tenacity import (
+    AsyncRetrying,
+    RetryError,
+    retry,
+    retry_if_exception_type,
+    retry_if_result,
+    stop_after_attempt,
+    wait_exponential,
+)
 from typing_extensions import Self
 
 from swerex.exceptions import SwerexException
@@ -37,6 +45,30 @@ from swerex.utils.log import get_logger
 from swerex.utils.wait import _wait_until_alive
 
 __all__ = ["RemoteRuntime", "RemoteRuntimeConfig"]
+
+
+def _is_retryable_exception(exc: BaseException) -> bool:
+    """Determine if an exception is retryable."""
+    if isinstance(
+        exc,
+        (
+            requests.exceptions.ConnectionError,
+            requests.exceptions.Timeout,
+            requests.exceptions.SSLError,
+        ),
+    ):
+        return True
+    if isinstance(exc, requests.exceptions.HTTPError):
+        # Retry on 5xx server errors, but not 4xx client errors
+        if hasattr(exc, "response") and exc.response is not None:
+            return 500 <= exc.response.status_code < 600 or exc.response.status_code in [408, 429]
+    return False
+
+
+def _is_retryable_status_code(response: requests.Response) -> bool:
+    """Determine if a status code is retryable."""
+    # Retry on 5xx server errors and some network-related codes
+    return 500 <= response.status_code < 600 or response.status_code in [408, 429]
 
 
 class RemoteRuntime(AbstractRuntime):
@@ -88,69 +120,31 @@ class RemoteRuntime(AbstractRuntime):
             return self._config.host
         return f"{self._config.host}:{self._config.port}"
 
-    def _should_retry_exception(self, exc: Exception) -> bool:
-        """Determine if an exception is retryable."""
-        if isinstance(exc, requests.exceptions.ConnectionError):
-            return True
-        if isinstance(exc, requests.exceptions.Timeout):
-            return True
-        if isinstance(exc, requests.exceptions.SSLError):
-            return True
-        if isinstance(exc, requests.exceptions.HTTPError):
-            # Retry on 5xx server errors, but not 4xx client errors
-            if hasattr(exc, 'response') and exc.response is not None:
-                return 500 <= exc.response.status_code < 600
-        return False
+    def _get_retry_decorator(self, safe_to_retry: bool = True) -> Any:
+        """Returns a tenacity retry decorator based on the instance's configuration."""
+        if not safe_to_retry:
+            return None  # No retry for unsafe operations
 
-    def _should_retry_status_code(self, status_code: int) -> bool:
-        """Determine if a status code is retryable."""
-        # Retry on 5xx server errors and some network-related codes
-        return 500 <= status_code < 600 or status_code in [408, 429]
-
-    def _retry_request(self, request_func, *args, safe_to_retry: bool = True, **kwargs):
-        """Execute a request function with retries."""
-        last_exception = None
-
-        for attempt in range(self.max_retries + 1):
-            try:
-                response = request_func(*args, **kwargs)
-
-                # Check if we should retry based on status code
-                if (attempt < self.max_retries and 
-                    safe_to_retry and 
-                    self._should_retry_status_code(response.status_code)):
-
-                    delay = self.retry_delay * (self.retry_backoff ** attempt)
-                    self.logger.warning(
-                        "Request failed with status %d, retrying in %.2f seconds (attempt %d/%d)",
-                        response.status_code, delay, attempt + 1, self.max_retries + 1
+        return retry(
+            stop=stop_after_attempt(self.max_retries + 1),
+            wait=wait_exponential(
+                multiplier=self.retry_backoff, min=self.retry_delay, max=self._config.timeout
+            ),
+            retry=(
+                retry_if_exception_type(
+                    (
+                        requests.exceptions.ConnectionError,
+                        requests.exceptions.Timeout,
+                        requests.exceptions.SSLError,
                     )
-                    time.sleep(delay)
-                    continue
-
-                return response
-
-            except Exception as exc:
-                last_exception = exc
-
-                if (attempt < self.max_retries and 
-                    safe_to_retry and 
-                    self._should_retry_exception(exc)):
-
-                    delay = self.retry_delay * (self.retry_backoff ** attempt)
-                    self.logger.warning(
-                        "Request failed with %s, retrying in %.2f seconds (attempt %d/%d): %s",
-                        type(exc).__name__, delay, attempt + 1, self.max_retries + 1, str(exc)
-                    )
-                    time.sleep(delay)
-                    continue
-
-                # If not retryable or out of retries, re-raise
-                raise
-
-        # If we get here, we've exhausted retries
-        if last_exception:
-            raise last_exception
+                )
+                | retry_if_result(_is_retryable_status_code)
+            ),
+            before_sleep=lambda retry_state: self.logger.warning(
+                "Request failed, retrying: %s", retry_state
+            ),
+            reraise=True,
+        )
 
     def _handle_transfer_exception(self, exc_transfer: _ExceptionTransfer) -> None:
         """Reraise exceptions that were thrown on the remote."""
@@ -202,13 +196,18 @@ class RemoteRuntime(AbstractRuntime):
         together with the message.
         """
         try:
-            response = self._retry_request(
-                requests.get,
-                f"{self._api_url}/is_alive",
-                headers=self._headers,
-                timeout=self._get_timeout(timeout),
-                safe_to_retry=True  # is_alive is safe to retry
-            )
+            retry_decorator = self._get_retry_decorator(safe_to_retry=True)
+
+            @retry_decorator
+            async def _is_alive_request():
+                return requests.get(
+                    f"{self._api_url}/is_alive",
+                    headers=self._headers,
+                    timeout=self._get_timeout(timeout),
+                )
+
+            response = await _is_alive_request()
+
             if response.status_code == 200:
                 return IsAliveResponse(**response.json())
             elif response.status_code == 511:
@@ -219,7 +218,7 @@ class RemoteRuntime(AbstractRuntime):
                 f"Message: {response.json().get('detail')}"
             )
             return IsAliveResponse(is_alive=False, message=msg)
-        except requests.RequestException:
+        except (requests.RequestException, RetryError):
             msg = f"Failed to connect to {self._config.host}\n"
             msg += traceback.format_exc()
             return IsAliveResponse(is_alive=False, message=msg)
@@ -231,85 +230,96 @@ class RemoteRuntime(AbstractRuntime):
     async def wait_until_alive(self, *, timeout: float = 60.0):
         return await _wait_until_alive(self.is_alive, timeout=timeout)
 
-    def _request(self, endpoint: str, request: BaseModel | None, output_class: Any, safe_to_retry: bool = True):
+    async def _request(
+        self, endpoint: str, request: BaseModel | None, output_class: Any, safe_to_retry: bool = True
+    ):
         """Small helper to make requests to the server and handle errors and output."""
-        response = self._retry_request(
-            requests.post,
-            f"{self._api_url}/{endpoint}",
-            json=request.model_dump() if request else None,
-            headers=self._headers,
-            safe_to_retry=safe_to_retry
-        )
-        self._handle_response_errors(response)
-        return output_class(**response.json())
+        retry_decorator = self._get_retry_decorator(safe_to_retry=safe_to_retry)
+
+        @retry_decorator
+        async def _make_request():
+            return requests.post(
+                f"{self._api_url}/{endpoint}",
+                json=request.model_dump() if request else None,
+                headers=self._headers,
+            )
+
+        try:
+            response = await _make_request()
+            self._handle_response_errors(response)
+            return output_class(**response.json())
+        except RetryError as e:
+            self.logger.error("Request failed after multiple retries: %s", e)
+            raise
 
     async def create_session(self, request: CreateSessionRequest) -> CreateSessionResponse:
         """Creates a new session."""
-        return self._request("create_session", request, CreateSessionResponse, safe_to_retry=True)
+        return await self._request("create_session", request, CreateSessionResponse, safe_to_retry=True)
 
     async def run_in_session(self, action: Action) -> Observation:
         """Runs a command in a session."""
         # This is potentially unsafe to retry as it might execute commands twice
-        return self._request("run_in_session", action, Observation, safe_to_retry=False)
+        return await self._request("run_in_session", action, Observation, safe_to_retry=False)
 
     async def close_session(self, request: CloseSessionRequest) -> CloseSessionResponse:
         """Closes a shell session."""
-        return self._request("close_session", request, CloseSessionResponse, safe_to_retry=True)
+        return await self._request("close_session", request, CloseSessionResponse, safe_to_retry=True)
 
     async def execute(self, command: Command) -> CommandResponse:
         """Executes a command (independent of any shell session)."""
         # This is potentially unsafe to retry as it might execute commands twice
-        return self._request("execute", command, CommandResponse, safe_to_retry=False)
+        return await self._request("execute", command, CommandResponse, safe_to_retry=False)
 
     async def read_file(self, request: ReadFileRequest) -> ReadFileResponse:
         """Reads a file"""
-        return self._request("read_file", request, ReadFileResponse, safe_to_retry=True)
+        return await self._request("read_file", request, ReadFileResponse, safe_to_retry=True)
 
     async def write_file(self, request: WriteFileRequest) -> WriteFileResponse:
         """Writes a file"""
         # File writes could be unsafe to retry depending on the write mode
         # Being conservative and not retrying by default
-        return self._request("write_file", request, WriteFileResponse, safe_to_retry=False)
+        return await self._request("write_file", request, WriteFileResponse, safe_to_retry=False)
 
     async def upload(self, request: UploadRequest) -> UploadResponse:
         """Uploads a file"""
         source = Path(request.source_path).resolve()
         self.logger.debug("Uploading file from %s to %s", request.source_path, request.target_path)
 
-        def _upload_request(files, data):
+        retry_decorator = self._get_retry_decorator(safe_to_retry=False)
+
+        @retry_decorator
+        async def _upload_request(files, data):
             return requests.post(f"{self._api_url}/upload", files=files, data=data, headers=self._headers)
 
-        if source.is_dir():
-            # Ignore cleanup errors: See https://github.com/SWE-agent/SWE-agent/issues/1005
-            with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as temp_dir:
-                zip_path = Path(temp_dir) / "zipped_transfer.zip"
-                shutil.make_archive(str(zip_path.with_suffix("")), "zip", source)
-                self.logger.debug("Created zip file at %s", zip_path)
-                files = {"file": zip_path.open("rb")}
-                data = {"target_path": request.target_path, "unzip": "true"}
+        try:
+            if source.is_dir():
+                # Ignore cleanup errors: See https://github.com/SWE-agent/SWE-agent/issues/1005
+                with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as temp_dir:
+                    zip_path = Path(temp_dir) / "zipped_transfer.zip"
+                    shutil.make_archive(str(zip_path.with_suffix("")), "zip", source)
+                    self.logger.debug("Created zip file at %s", zip_path)
+                    with open(zip_path, "rb") as f:
+                        files = {"file": f}
+                        data = {"target_path": request.target_path, "unzip": "true"}
+                        response = await _upload_request(files, data)
+                    self._handle_response_errors(response)
+                    return UploadResponse(**response.json())
 
-                # Uploads might be unsafe to retry if they partially succeed
-                response = self._retry_request(
-                    _upload_request, files, data, safe_to_retry=False
-                )
+            elif source.is_file():
+                self.logger.debug("Uploading file from %s to %s", source, request.target_path)
+                with open(source, "rb") as f:
+                    files = {"file": f}
+                    data = {"target_path": request.target_path, "unzip": "false"}
+                    response = await _upload_request(files, data)
                 self._handle_response_errors(response)
                 return UploadResponse(**response.json())
-
-        elif source.is_file():
-            self.logger.debug("Uploading file from %s to %s", source, request.target_path)
-            files = {"file": source.open("rb")}
-            data = {"target_path": request.target_path, "unzip": "false"}
-
-            # Uploads might be unsafe to retry if they partially succeed
-            response = self._retry_request(
-                _upload_request, files, data, safe_to_retry=False
-            )
-            self._handle_response_errors(response)
-            return UploadResponse(**response.json())
-        else:
-            msg = f"Source path {source} is not a file or directory"
-            raise ValueError(msg)
+            else:
+                msg = f"Source path {source} is not a file or directory"
+                raise ValueError(msg)
+        except RetryError as e:
+            self.logger.error("Upload failed after multiple retries: %s", e)
+            raise
 
     async def close(self) -> CloseResponse:
         """Closes the runtime."""
-        return self._request("close", None, CloseResponse, safe_to_retry=True)
+        return await self._request("close", None, CloseResponse, safe_to_retry=True)


### PR DESCRIPTION
### Summary

Add patch for SWEAP support in SWE-ReX

### Notes
- In order to run SWEAP instances with swe-agent, the image building logic needs some changes which currently reside in here: https://github.com/scaleapi/models/tree/master/agent/evals/swe/SWE-agent/swerex_patches
- Adding 1 commit with SWEAP support, and 1 commit which add in HTTP retries in the swerex library (without which we see several network errors in large scale jobs).
- Also increased the modal sandbox timeout to 1 hour by default.

### Testing
- Tested using this patch by adding the following changes in the sweagent wrapper dockerfile
```
RUN git clone -b sweagent_patch --single-branch https://github.com/mayavkrishnan25/SWE-ReX.git /SWE-ReX
WORKDIR /SWE-ReX
RUN pip install -e .
```
Config used:
```
output_dir: results/sweagent/0613/claude_test
sweagent_command: |
  sweagent run-batch \
    --config config/scale_default.yaml \
    --output_dir {output_dir} \
    --num_workers 1 \
    --random_delay_multiplier 1 \
    --instances.type file \
    --instances.path data/instances.yaml \
    --instances.slice :1 \
    --instances.shuffle=False \
    --instances.deployment.type=modal \
    --agent.model.name litellm_proxy/anthropic/claude-3-7-sonnet-20250219 \
    --agent.model.api_base https://litellm.ml.scaleinternal.com/ \
    --agent.model.api_key $OPENAI_API_KEY
```

And was able to run swe-agent end to end and get a prediction.